### PR TITLE
don't strip "/" in string data

### DIFF
--- a/test/where/where.spec.js
+++ b/test/where/where.spec.js
@@ -212,9 +212,19 @@ describe('where.js [core jasmine spec]', function () {
         expect(number).toBe(2);
         expect(numberString).toBe('\'4\'');
       });
-      
     });
-    
+
+    it('should not strip "/"', function() {
+      where(function() {
+        /***
+            date
+            01/01/1970   // comment
+         // 02/02/1972
+         ***/
+        expect(typeof date).toBe('string');
+        expect(date).toBe('01/01/1970');
+      })
+    });
   });
 
   /* empty vs. bordered data */

--- a/where.js
+++ b/where.js
@@ -236,7 +236,7 @@
     
     // convert table into an array of row data
     var data = table.replace(/\/\/[^\r]*/g, '') // remove line comments...
-                    .replace(/[\/\*]*[\r]*[\*\/]*/g, '') // ...block comments
+                    .replace(/(\/\*+)*[\r]*(\*+\/)*/g, '') // ...block comments
                     .split('\n'); // and split by newline
     
     var rows = [];


### PR DESCRIPTION
String input will lose "/" characters because of comment cleanup regular expressions.
An example for such an input would be formatted dates (01/01/1970)

My suggestion for the fix is to reformulate the cleanup regular expressions by simply grouping the comment identifier. An example can be reviewed on following debuggex https://www.debuggex.com/r/ZKeWxc6sKlPLuD_H 
