### PR TITLE
Fix problem in jasmine strategy when an error is thrown in test function...

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "test": "jasmine-node --verbose ./test/where/where.spec.js",
-    "jasmine": "jasmine-node --verbose --matchall ./test/jasmine/where-spec",
+    "jasmine": "jasmine-node --verbose --matchall ./test/jasmine/where-spec.js",
     "mocha": "node ./test/mocha/node-suite.js",
     "qunit": "node ./test/qunit/node-suite.js",
     "tape": "node ./test/tape/node-suite.js",

--- a/test/jasmine/where-spec.js
+++ b/test/jasmine/where-spec.js
@@ -73,7 +73,7 @@ describe('where.js [jasmine tests]', function () {
 
   });
   
-  it('should throw unintercepted errors', function() {
+  it('should throw unintercepted expectation errors', function() {
 
     expect(function() {
     
@@ -88,6 +88,18 @@ describe('where.js [jasmine tests]', function () {
      
     }).toThrow();
     
+  });
+
+  it('should throw unintercepted errors', function() {
+    expect(function() {
+        where(function() {
+            /***
+              | a | b | c |
+              | 1 | 2 | 2 |
+              ***/
+              throw new Error('some error');
+          }, { jasmine: jasmine, expect: expect });
+      }).toThrow();
   });
   
 // UNCOMMENT THIS TEST TO SEE STACK OUTPUT FOR FAILING WHERE() ASSERTION

--- a/where.js
+++ b/where.js
@@ -485,16 +485,19 @@
       });
       
       /* execute on currentSpec for jasmine 1.x.x */
-      fnTest.apply(currentSpec, [context].concat(value));
-    
-      /* restore result api */
-      
-      /* jasmine 1.x.x. */ 
-      addResult && (result.addResult = addResult);
-      
-      /* jasmine 2.x.x. */ 
-      addExpectationResult && 
-      (jasmine.Spec.prototype.addExpectationResult = addExpectationResult);     
+      try {
+        fnTest.apply(currentSpec, [context].concat(value));
+      }
+      finally {
+        /* restore result api */
+
+        /* jasmine 1.x.x. */
+        addResult && (result.addResult = addResult);
+
+        /* jasmine 2.x.x. */
+        addExpectationResult &&
+        (jasmine.Spec.prototype.addExpectationResult = addExpectationResult);
+      }
     };        
   });
   


### PR DESCRIPTION
To recognize expectation failures for jasmine a retargeting of the result handler functions on the jasmine spec is performed. That should be guarded with a try-finally statement!

When an Error is thrown in the where test function, the retargeted spec api will leak out of the where testcode and influence further test execution.
